### PR TITLE
Fix error when changing brightness value

### DIFF
--- a/ledfx/effects/__init__.py
+++ b/ledfx/effects/__init__.py
@@ -52,7 +52,7 @@ def blur_pixels(pixels, sigma):
     return rgb_array.T
 
 def brightness_pixels(pixels, brightness):
-    pixels *= brightness
+    pixels = np.multiply(pixels, brightness, out=pixels, casting="unsafe")
     return pixels
 
 @lru_cache(maxsize=32)


### PR DESCRIPTION
Most of the time, changing the brightness value will throw the error `Cannot cast ufunc multiply output from dtype('float64') to dtype('int32') with casting rule 'same_kind'`. Using numpy instead of the *= function will solve this error, making modifying the brightness level work as expected.